### PR TITLE
Fuzzy matching no longer seems to be a preference

### DIFF
--- a/src/Web/Slack/Types/Preferences.hs
+++ b/src/Web/Slack/Types/Preferences.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE TemplateHaskell, LambdaCase #-}
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Web.Slack.Types.Preferences where
 
 import           Data.Aeson.TH
-import Data.Text (Text)
+import           Data.Text       (Text)
 import           Web.Slack.Utils
 --import Control.Lens.TH
 
@@ -87,7 +88,6 @@ data Preferences = Preferences
                  , _prefMutedChannels                   :: Text
                  , _prefPrivacyPolicySeen               :: Bool
                  , _prefSearchExcludeBots               :: Bool
-                 , _prefFuzzyMatching                   :: Bool
                  } deriving Show
 
 


### PR DESCRIPTION
I was just messing with the [slack-lambdabot](https://github.com/markandrus/slack-lambdabot), using your fork of slack-api, and slack-api started having parse errors on `Preferences` because `fuzzy_matching` was not present. I couldn't find any references to `fuzzy_matching` in the slack docs. So, I just removed it.